### PR TITLE
Fix rsh command flags order

### DIFF
--- a/etcd.sh
+++ b/etcd.sh
@@ -43,7 +43,7 @@ help_etcd_objects() {
   echo -e ""
   echo -e "List number of objects in ETCD:"
   echo -e ""
-  echo -e "oc rsh <etcd pod> -n openshift-etcd -c etcd"
+  echo -e "oc rsh -c etcd -n openshift-etcd <etcd pod>"
   echo -e "> etcdctl get / --prefix --keys-only | sed '/^$/d' | cut -d/ -f3 | sort | uniq -c | sort -rn"
   echo -e ""
   echo -e "[HINT] Any number of CRDs (secrets, deployments, etc..) above 8k could cause performance issues on storage with not enough IOPS."

--- a/must.sh
+++ b/must.sh
@@ -43,7 +43,7 @@ help_etcd_objects() {
   echo -e ""
   echo -e "List number of objects in ETCD:"
   echo -e ""
-  echo -e "oc rsh <etcd pod> -n openshift-etcd -c etcd"
+  echo -e "oc rsh -c etcd -n openshift-etcd <etcd pod>"
   echo -e "> etcdctl get / --prefix --keys-only | sed '/^$/d' | cut -d/ -f3 | sort | uniq -c | sort -rn"
   echo -e ""
   echo -e "[HINT] Any number of CRDs (secrets, deployments, etc..) above 8k could cause performance issues on storage with not enough IOPS."


### PR DESCRIPTION
Hi Peter,
  the rsh command as echoed by scripts is not working:
```
$ oc rsh <etcd pod> -n openshift-etcd -c etcd
Defaulted container "etcdctl" out of: etcdctl, etcd, etcd-metrics, etcd-health-monitor, setup (init), etcd-ensure-env-vars (init), etcd-resources-copy (init)
ERRO[0000] exec failed: container_linux.go:380: starting container process caused: exec: "-n": executable file not found in $PATH 
command terminated with exit code 1
```

since the last parameter in oc rsh is command to execute:
```
Usage:
  oc rsh [-c CONTAINER] [flags] (POD | TYPE/NAME) COMMAND [args...]
```